### PR TITLE
Set non-strict dependencies versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ setup(
     ],
     python_requires='>=3.8',
     install_requires=[
-        "azure-identity==1.10.0",
+        "azure-identity>=1.10.0",
         "pytest",
         "requests_mock",
         "cryptography>=3.2",
-        "pyjwt==2.4.0", 
-        "opentelemetry-instrumentation-requests==0.31b0"
+        "pyjwt>=2.4.0", 
+        "opentelemetry-instrumentation-requests>=0.31b0"
     ]
 )


### PR DESCRIPTION
# Pull Request Template

## Description

Using the SDK from inside Azure ML Compute instance by default requires azure-identity of a version greater than `1.10.0` (at least it works with `1.13.0`).

Though, having the version explicitly pinned to `1.10.0` does not allow to bump it for the applications that require a higher version.

This PR also sets non-strict versions for the other dependencies, to not limit the opportunity to upgrade them

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Tried to pin a higher version of `azure-identity`.  Eventually, installed it manually with `pip install azure-identity==1.13.0` to see if it solves the issue.

**Test Configuration**:
* Environment: N/A

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the architecture
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
