### PR TITLE
Fix parsing of empty body when 502 error happens due to timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "omnia_timeseries"
-version = "1.3.6"
+version = "1.3.7"
 authors = ["Equinor Omnia Industrial IoT Team <omniaindiot@equinor.com>"]
 homepage = "https://github.com/equinor/omnia-timeseries-python"
 repository = "https://github.com/equinor/omnia-timeseries-python"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files=test_*.py
+python_functions=*

--- a/src/omnia_timeseries/api.py
+++ b/src/omnia_timeseries/api.py
@@ -1,6 +1,6 @@
 from typing import List, Literal, Optional
 from azure.identity._internal.msal_credentials import MsalCredential
-from omnia_timeseries.http_client import HttpClient, ContentType, RequestType
+from omnia_timeseries.http_client import HttpClient, ContentType
 from omnia_timeseries.models import (
     DatapointModel,
     DatapointsItemsModel, DatapointsPostRequestModel,

--- a/src/omnia_timeseries/models.py
+++ b/src/omnia_timeseries/models.py
@@ -184,7 +184,7 @@ class StreamSubscriptionDataModel(TypedDict):
 
 class TimeseriesRequestFailedException(Exception):
     def __init__(self, response: Response) -> None:
-        error = json.loads(response.text)
+        error = {"message":"Response is empty"} if response.text == '' else json.loads(response.text)
         self._status_code = response.status_code
         self._reason = response.reason
         self._message = error["message"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,9 +1,7 @@
-import unittest
 import requests_mock
 import pytest
 from azure.identity._internal.msal_credentials import MsalCredential
 from azure.core.credentials import AccessToken
-from requests.models import Response
 from omnia_timeseries import TimeseriesAPI, TimeseriesEnvironment
 from omnia_timeseries.http_client import TimeseriesRequestFailedException
 
@@ -23,20 +21,37 @@ def api():
     api = TimeseriesAPI(DummyCredentials("dummy"), env)
     return api
 
-
-def test_retry_on_failure(api):
+def should_retry_request_when_failing_on_retryable_error_code_503_service_is_unavailable(api):
     with requests_mock.Mocker() as m:
-        m.register_uri("GET", "https://test/1234/data/latest", status_code=503,  # 503 is retryable
+        m.register_uri("GET", "https://test/1234/data/latest", status_code=503,
                        text="""{"message": "Service is unavailable", "traceId": "1"}""")
         with pytest.raises(TimeseriesRequestFailedException):
             api.get_latest_datapoint("1234")
     assert m.call_count == 3, "Unexpected number of retries"
 
-
-def test_skip_retry_when_not_retryable_status_code(api):
+def should_not_retry_request_when_failing_on_non_retryable_error_code_403_forbidden(api):
     with requests_mock.Mocker() as m:
-        m.register_uri("GET", "https://test/1234/data/latest", status_code=403,  # 403 is not retryable
+        m.register_uri("GET", "https://test/1234/data/latest", status_code=403,
                        text="""{"message": "Service is unavailable", "traceId": "1"}""")
         with pytest.raises(TimeseriesRequestFailedException):
             api.get_latest_datapoint("1234")
     assert m.call_count == 1, "Unexpected number of retries"
+
+def should_correctly_parse_empty_response_when_failing_on_502_bad_gateway_due_to_api_timeout(api):
+    with requests_mock.Mocker() as m:
+        m.register_uri("POST", "https://test/query/data", status_code=502, text="")
+
+        with pytest.raises(TimeseriesRequestFailedException):
+            api.get_multi_datapoints([
+                {
+                    "id": "some guid",
+                    "statusFilter": [192],
+                    "includeOutsidePoints": False,
+                    "startTime": "2022-01-01T00:00:00.000Z",
+                    "endTime": "2022-01-02T00:00:00.000Z",
+                    "aggregateFunctions": ["avg"],
+                    "processingInterval": "1h",
+                    "fill": "none"
+                },
+            ])
+    assert m.call_count == 3, "Unexpected number of retries"


### PR DESCRIPTION
## Description
- Fix sdk failing to parse error response, when error response is empty due to 502 bad gateway error which was caused by api timeout
- Updated naming of tests to be more clear, to avoid using comments
- Enabling any naming convention for tests for given test python files, with pytest ini file
- Removed unused using statements
- Bumping version

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Debugged sdk locally and ran old and new tests.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the architecture
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes