### PR TITLE
Improve error handling when response text is non json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "omnia_timeseries"
-version = "1.3.7"
+version = "1.3.8"
 authors = ["Equinor Omnia Industrial IoT Team <omniaindiot@equinor.com>"]
 homepage = "https://github.com/equinor/omnia-timeseries-python"
 repository = "https://github.com/equinor/omnia-timeseries-python"

--- a/src/omnia_timeseries/models.py
+++ b/src/omnia_timeseries/models.py
@@ -184,7 +184,10 @@ class StreamSubscriptionDataModel(TypedDict):
 
 class TimeseriesRequestFailedException(Exception):
     def __init__(self, response: Response) -> None:
-        error = {"message":"Response is empty"} if response.text == '' else json.loads(response.text)
+        try:
+            error=json.loads(response.text)
+        except:
+            error={"message": f"Could not load response, raw response: '{response.text}'"}
         self._status_code = response.status_code
         self._reason = response.reason
         self._message = error["message"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,9 +37,10 @@ def should_not_retry_request_when_failing_on_non_retryable_error_code_403_forbid
             api.get_latest_datapoint("1234")
     assert m.call_count == 1, "Unexpected number of retries"
 
-def should_correctly_parse_empty_response_when_failing_on_502_bad_gateway_due_to_api_timeout(api):
+@pytest.mark.parametrize("responseText",[(""),("blah")])
+def should_try_parse_response_when_failing_on_502_bad_gateway_due_to_api_timeout(api, responseText):
     with requests_mock.Mocker() as m:
-        m.register_uri("POST", "https://test/query/data", status_code=502, text="")
+        m.register_uri("POST", "https://test/query/data", status_code=502, text=responseText)
 
         with pytest.raises(TimeseriesRequestFailedException):
             api.get_multi_datapoints([


### PR DESCRIPTION
## Description
- Change to try parse response text when exceptions occur, in order to also handle non-empty, non-json responses
- Add test to cover new failure scenario

## Type of change

- [x] Bug fix (non-breaking change which fixes [28421](https://dev.azure.com/Plant-Data-Platform-Team/Omnia%20Industrial%20IoT%20Team/_workitems/edit/28421))

## How Has This Been Tested?

- [x] Ran api tests with local sdk build
- [x] Used local package to get data response from test environment: https://github.com/equinor/omnia-timeseries-python?tab=readme-ov-file#with-default-credentials-azure-cli-msi-and-so-on

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the architecture
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes