### PR TITLE
Feature/31573 add other api clients to interface with and reuse timeseries environment

### DIFF
--- a/examples/usage_examples.ipynb
+++ b/examples/usage_examples.ipynb
@@ -31,7 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from omnia_timeseries.api import TimeseriesAPI, TimeseriesEnvironment, FederationSource\n",
+    "from omnia_timeseries.api import TimeseriesAPI, IMSMetadataAPI, IMSSubscriptionsAPI, TimeseriesEnvironment, FederationSource\n",
     "import os"
    ]
   },
@@ -122,7 +122,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "api = TimeseriesAPI(azure_credential=credentials, environment=TimeseriesEnvironment.Dev())"
+    "environment=TimeseriesEnvironment.Dev()\n",
+    "api = TimeseriesAPI(azure_credential=credentials, environment=environment)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "omnia_timeseries"
-version = "1.4.3"
+version = "1.4.4"
 description = "Official Python SDK for the Omnia Timeseries API"
 readme = "README.md"
 authors = ["Equinor Omnia Industrial IoT Team <omniaindiot@equinor.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ opentelemetry-instrumentation-requests = ">=0.54b1,<1.0.0"
 opentelemetry-api = ">=1.27.0,<2.0.0"
 cryptography = ">=46.0.5,<47.0.0"
 pyjwt = ">=2.9.0,<3.0.0"
+typing_extensions = ">=4.15.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.4.0,<9.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ opentelemetry-instrumentation-requests = ">=0.54b1,<1.0.0"
 opentelemetry-api = ">=1.27.0,<2.0.0"
 cryptography = ">=46.0.5,<47.0.0"
 pyjwt = ">=2.9.0,<3.0.0"
-typing_extensions = ">=4.15.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.4.0,<9.0.0"

--- a/src/omnia_timeseries/api.py
+++ b/src/omnia_timeseries/api.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict, List, Literal, Optional
-from azure.identity._internal.msal_credentials import MsalCredential
+from azure.core.credentials import TokenCredential
 from omnia_timeseries.http_client import HttpClient, ContentType
 from omnia_timeseries.models import (
     DatapointModel,
@@ -103,7 +103,7 @@ class TimeseriesAPI:
     """
 
     def __init__(
-        self, azure_credential: MsalCredential, environment: TimeseriesEnvironment
+        self, azure_credential: TokenCredential, environment: TimeseriesEnvironment
     ):
         self._http_client = HttpClient(
             azure_credential=azure_credential, resource_id=environment.resource_id

--- a/src/omnia_timeseries/api.py
+++ b/src/omnia_timeseries/api.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional
-from typing_extensions import Self # Python 3.8 compatible
 from azure.core.credentials import TokenCredential
 from omnia_timeseries.http_client import HttpClient, ContentType
 from omnia_timeseries.models import (
@@ -62,21 +61,21 @@ class TimeseriesEnvironment:
     kind: Environment
 
     @classmethod
-    def Dev(cls) -> Self:
+    def Dev(cls) -> "TimeseriesEnvironment":
         """
         Set non-production dev environment
         """
         return cls(kind=Environment.Dev)
 
     @classmethod
-    def Test(cls) -> Self:
+    def Test(cls) -> "TimeseriesEnvironment":
         """
         Set non-production test environment
         """
         return cls(kind=Environment.Test)
 
     @classmethod
-    def Prod(cls) -> Self:
+    def Prod(cls) -> "TimeseriesEnvironment":
         """
         Set production environment
         """
@@ -310,7 +309,7 @@ class IMSSubscriptionsAPI:
         if continuationToken is not None:
             params["continuationToken"] = continuationToken
         url = (
-            f"{self._base_url}/uid"
+            f"{self._base_url}/uid/{uid}"
         )
         return self._http_client.request(request_type="get", url=url, params=params)
 
@@ -329,7 +328,7 @@ class IMSSubscriptionsAPI:
         if continuationToken is not None:
             params["continuationToken"] = continuationToken
         url = (
-            f"{self._base_url}/timeseriesId"
+            f"{self._base_url}/timeseriesId/{timeseriesId}"
         )
         return self._http_client.request(request_type="get", url=url, params=params)
 

--- a/src/omnia_timeseries/api.py
+++ b/src/omnia_timeseries/api.py
@@ -1,4 +1,6 @@
+from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional
+from typing_extensions import Self # Python 3.8 compatible
 from azure.core.credentials import TokenCredential
 from omnia_timeseries.http_client import HttpClient, ContentType
 from omnia_timeseries.models import (
@@ -11,16 +13,21 @@ from omnia_timeseries.models import (
     GetHistoryResponseModel,
     GetMultipleDatapointsRequestItem,
     GetTimeseriesResponseModel,
+    GetIMSMetadataResponseModel,
     SourceDataModel,
     MessageModel,
     StreamSubscriptionRequestModel,
     StreamSubscriptionDataModel,
+    SubscriptionCounterModel,
+    SubscriptionPatchRequestItem,
     TimeseriesPatchRequestItem,
     TimeseriesRequestItem,
 )
 import logging
 from enum import Enum
 
+IMSMetadataVersion = Literal["1.3"]
+IMSSubscriptionsVersion = Literal["1.2"]
 TimeseriesVersion = Literal["1.6", "1.7"]
 
 logger = logging.getLogger(__name__)
@@ -42,47 +49,63 @@ class FederationSource(Enum):
     TSDB = "TSDB"
     DataLake = "DataLake"
 
+# Internal enum to represent environment chosen by user via TimeseriesEnvironment
+class Environment(Enum):
+    Dev = "dev"
+    Test = "test"
+    Prod = "prod"
 
+# User-facing, immutable token accepted by all APIs with Python v3.8 slots-like behaviour
+@dataclass(frozen=True)
 class TimeseriesEnvironment:
-    def __init__(self, resource_id: str, base_url: str):
-        """
-        Wrapper class for defining which timeseries environment the TimeseriesAPI client will interface to
-
-        :param str resource_id: Resource/client id of API app registration (Azure SPN)
-        :param str base_url: Baze url of API
-        """
-        self._resource_id = resource_id
-        self._base_url = base_url
+    __slots__ = ("kind",)
+    kind: Environment
 
     @classmethod
-    def Dev(cls, version: TimeseriesVersion = "1.7"):
+    def Dev(cls) -> Self:
         """
-        Sets up non-production dev environment
+        Set non-production dev environment
         """
-        return cls(
-            resource_id="32f2a909-8a98-4eb8-b22d-1208d9350cb0",
-            base_url=f"https://api-dev.gateway.equinor.com/plant/timeseries/v{version}",
-        )
+        return cls(kind=Environment.Dev)
 
     @classmethod
-    def Test(cls, version: TimeseriesVersion = "1.7"):
+    def Test(cls) -> Self:
         """
-        Sets up non-production environment
+        Set non-production test environment
         """
-        return cls(
-            resource_id="32f2a909-8a98-4eb8-b22d-1208d9350cb0",
-            base_url=f"https://api-test.gateway.equinor.com/plant/timeseries/v{version}",
-        )
+        return cls(kind=Environment.Test)
 
     @classmethod
-    def Prod(cls, version: TimeseriesVersion = "1.7"):
+    def Prod(cls) -> Self:
         """
-        Sets up production environment
+        Set production environment
         """
-        return cls(
-            resource_id="141369bd-3dca-4b55-825b-56ad4a69b1fc",
-            base_url=f"https://api.gateway.equinor.com/plant/timeseries/v{version}",
-        )
+        return cls(kind=Environment.Prod)
+
+class IMSMetadataApiEnvironment:
+    def __init__(self, environment: TimeseriesEnvironment, version: IMSMetadataVersion = "1.3"):
+        """
+        Wrapper class for defining which environment the IMS Metadata API client will interface to
+
+        :param TimeseriesEnvironment environment: Value with environment chosen as dev, test or prod
+        """
+
+        # Prepare API connection details
+        if environment.kind is Environment.Dev:
+            self._resource_id = "310547f5-022b-4fb5-b13e-2b468b8bf658"
+            self._base_url = f"https://api-dev.gateway.equinor.com/plant/ims-metadata/v{version}"
+
+        if environment.kind is Environment.Test:
+            self._resource_id = "310547f5-022b-4fb5-b13e-2b468b8bf658"
+            self._base_url = f"https://api-test.gateway.equinor.com/plant/ims-metadata/v{version}"
+
+        if environment.kind is Environment.Prod:
+            self._resource_id = "71415e4e-7131-4a81-9596-f921978cdbee"
+            self._base_url = f"https://api.gateway.equinor.com/plant/ims-metadata/v{version}"
+
+        # Safeguard in case of new, unsupported environment
+        if not hasattr(self, "_resource_id") or not hasattr(self, "_base_url"):
+            raise ValueError(f"Unsupported environment: {environment.kind!r}")
 
     @property
     def resource_id(self) -> str:
@@ -92,10 +115,108 @@ class TimeseriesEnvironment:
     def base_url(self) -> str:
         return self._base_url
 
+class IMSSubscriptionsAPIEnvironment:
+    def __init__(self, environment: TimeseriesEnvironment, version: IMSSubscriptionsVersion = "1.2"):
+        """
+        Wrapper class for defining which environment the IMS Subscriptions API client will interface to
 
-class TimeseriesAPI:
+        :param TimeseriesEnvironment environment: Value with environment chosen as dev, test or prod
+        """
+
+        # Prepare API connection details
+        if environment.kind is Environment.Dev:
+            self._resource_id = "789d768e-32ac-417b-b286-be5e0d460809"
+            self._base_url = f"https://api-dev.gateway.equinor.com/plant/ims-subscriptions/v{version}"
+
+        if environment.kind is Environment.Test:
+            self._resource_id = "789d768e-32ac-417b-b286-be5e0d460809"
+            self._base_url = f"https://api-test.gateway.equinor.com/plant/ims-subscriptions/v{version}"
+
+        if environment.kind is Environment.Prod:
+            self._resource_id = "cae23674-f25d-40a2-b9e4-81649b33b957"
+            self._base_url = f"https://api.gateway.equinor.com/plant/ims-subscriptions/v{version}"
+
+        # Safeguard in case of new, unsupported environment
+        if not hasattr(self, "_resource_id") or not hasattr(self, "_base_url"):
+            raise ValueError(f"Unsupported environment: {environment.kind!r}")
+
+    @property
+    def resource_id(self) -> str:
+        return self._resource_id
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+class IMSSubscriptionsManagementAPIEnvironment:
+    def __init__(self, environment: TimeseriesEnvironment, version: IMSSubscriptionsVersion = "1.2"):
+        """
+        Wrapper class for defining which environment the IMS Subscriptions Management API client will interface to
+
+        :param TimeseriesEnvironment environment: Value with environment chosen as dev, test or prod
+        """
+
+        # Prepare API connection details
+        if environment.kind is Environment.Dev:
+            self._resource_id = "789d768e-32ac-417b-b286-be5e0d460809"
+            self._base_url = f"https://api-dev.gateway.equinor.com/plant/ims-subscriptions-management/v{version}"
+
+        if environment.kind is Environment.Test:
+            self._resource_id = "789d768e-32ac-417b-b286-be5e0d460809"
+            self._base_url = f"https://api-test.gateway.equinor.com/plant/ims-subscriptions-management/v{version}"
+
+        if environment.kind is Environment.Prod:
+            self._resource_id = "cae23674-f25d-40a2-b9e4-81649b33b957"
+            self._base_url = f"https://api.gateway.equinor.com/plant/ims-subscriptions-management/v{version}"
+
+        # Safeguard in case of new, unsupported environment
+        if not hasattr(self, "_resource_id") or not hasattr(self, "_base_url"):
+            raise ValueError(f"Unsupported environment: {environment.kind!r}")
+
+    @property
+    def resource_id(self) -> str:
+        return self._resource_id
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+class TimeseriesApiEnvironment:
+    def __init__(self, environment: TimeseriesEnvironment, version: TimeseriesVersion = "1.7"):
+        """
+        Wrapper class for defining which environment the Timeseries API client will interface to
+
+        :param TimeseriesEnvironment environment: Value with environment chosen as dev, test or prod
+        """
+
+        # Prepare API connection details
+        if environment.kind is Environment.Dev:
+            self._resource_id = "32f2a909-8a98-4eb8-b22d-1208d9350cb0"
+            self._base_url = f"https://api-dev.gateway.equinor.com/plant/timeseries/v{version}"
+
+        if environment.kind is Environment.Test:
+            self._resource_id = "32f2a909-8a98-4eb8-b22d-1208d9350cb0"
+            self._base_url = f"https://api-test.gateway.equinor.com/plant/timeseries/v{version}"
+
+        if environment.kind is Environment.Prod:
+            self._resource_id = "141369bd-3dca-4b55-825b-56ad4a69b1fc"
+            self._base_url = f"https://api.gateway.equinor.com/plant/timeseries/v{version}"
+
+        # Safeguard in case of new, unsupported environment
+        if not hasattr(self, "_resource_id") or not hasattr(self, "_base_url"):
+            raise ValueError(f"Unsupported environment: {environment.kind!r}")
+
+    @property
+    def resource_id(self) -> str:
+        return self._resource_id
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+class IMSMetadataAPI:
     """
-    Wrapper class for interacting with the Omnia Industrial IIoT Timeseries API.
+    Wrapper class for interacting with the Omnia Industrial IIoT IMS Metadata API.
     For more information, see https://github.com/equinor/OmniaPlant/wiki or consult with the Omnia IIoT team.
 
     :param MsalCredential azure_credential: Azure credential instance used for authenticating
@@ -105,10 +226,193 @@ class TimeseriesAPI:
     def __init__(
         self, azure_credential: TokenCredential, environment: TimeseriesEnvironment
     ):
+        if not isinstance(environment, TimeseriesEnvironment):
+            raise TypeError(f"Environment must be TimeseriesEnvironment, got: {type(environment).__name__}")
+        apiEnvironment=IMSMetadataApiEnvironment(environment)
         self._http_client = HttpClient(
-            azure_credential=azure_credential, resource_id=environment.resource_id
+            azure_credential=azure_credential, resource_id=apiEnvironment.resource_id
         )
-        self._base_url = environment.base_url.rstrip("/")
+        self._base_url = apiEnvironment.base_url.rstrip("/")
+
+    def search(
+        self,
+        tag: Optional[str] = None,
+        uid: Optional[str] = None,
+        continuationToken: Optional[str] = None,
+        **kwargs,
+    ) -> GetIMSMetadataResponseModel:
+        """
+        Search IMS Metadata API
+        """
+        params = kwargs or {}
+        if tag is not None:
+            params["tag"] = tag
+        if uid is not None:
+            params["uid"] = uid
+        if continuationToken is not None:
+            params["continuationToken"] = continuationToken
+        url = (
+            f"{self._base_url}/search"
+        )
+        return self._http_client.request(request_type="get", url=url, params=params)
+
+class IMSSubscriptionsAPI:
+    """
+    Wrapper class for interacting with the Omnia Industrial IIoT IMS Subscriptions API.
+    For more information, see https://github.com/equinor/OmniaPlant/wiki or consult with the Omnia IIoT team.
+
+    :param MsalCredential azure_credential: Azure credential instance used for authenticating
+    :param TimeseriesEnvironment environment: API deployment environment
+    """
+
+    def __init__(
+        self, azure_credential: TokenCredential, environment: TimeseriesEnvironment
+    ):
+        if not isinstance(environment, TimeseriesEnvironment):
+            raise TypeError(f"Environment must be TimeseriesEnvironment, got: {type(environment).__name__}")
+        apiEnvironment=IMSSubscriptionsAPIEnvironment(environment)
+        self._http_client = HttpClient(
+            azure_credential=azure_credential, resource_id=apiEnvironment.resource_id
+        )
+        self._base_url = apiEnvironment.base_url.rstrip("/")
+
+    def search(
+        self,
+        limit: Optional[int] = 1000,
+        continuationToken: Optional[str] = None,
+        **kwargs,
+    ) -> GetIMSMetadataResponseModel:
+        """
+        Search IMS Subscriptions API
+        """
+        params = kwargs or {}
+        if limit is not None:
+            params["limit"] = limit
+        if continuationToken is not None:
+            params["continuationToken"] = continuationToken
+        url = (
+            f"{self._base_url}"
+        )
+        return self._http_client.request(request_type="get", url=url, params=params)
+
+    def search_by_uid(
+        self,
+        uid: Optional[str] = None,
+        continuationToken: Optional[str] = None,
+        **kwargs,
+    ) -> GetIMSMetadataResponseModel:
+        """
+        Search IMS Subscriptions API
+        """
+        params = kwargs or {}
+        if uid is not None:
+            params["uid"] = uid
+        if continuationToken is not None:
+            params["continuationToken"] = continuationToken
+        url = (
+            f"{self._base_url}/uid"
+        )
+        return self._http_client.request(request_type="get", url=url, params=params)
+
+    def search_by_timeseries_id(
+        self,
+        timeseriesId: Optional[str] = None,
+        continuationToken: Optional[str] = None,
+        **kwargs,
+    ) -> GetIMSMetadataResponseModel:
+        """
+        Search IMS Subscriptions API
+        """
+        params = kwargs or {}
+        if timeseriesId is not None:
+            params["timeseriesId"] = timeseriesId
+        if continuationToken is not None:
+            params["continuationToken"] = continuationToken
+        url = (
+            f"{self._base_url}/timeseriesId"
+        )
+        return self._http_client.request(request_type="get", url=url, params=params)
+
+    def search_by_system_code(
+        self,
+        systemCode: str,
+        **kwargs,
+    ) -> SubscriptionCounterModel:
+        """
+        Search IMS Subscriptions API
+        """
+        params = kwargs or {}
+        url = (
+            f"{self._base_url}/{systemCode}"
+        )
+        return self._http_client.request(request_type="get", url=url, params=params)
+
+class IMSSubscriptionsManagementAPI:
+    """
+    Wrapper class for interacting with the Omnia Industrial IIoT IMS Subscriptions Management API.
+    For more information, see https://github.com/equinor/OmniaPlant/wiki or consult with the Omnia IIoT team.
+
+    :param MsalCredential azure_credential: Azure credential instance used for authenticating
+    :param TimeseriesEnvironment environment: API deployment environment
+    """
+
+    def __init__(
+        self, azure_credential: TokenCredential, environment: TimeseriesEnvironment
+    ):
+        if not isinstance(environment, TimeseriesEnvironment):
+            raise TypeError(f"Environment must be TimeseriesEnvironment, got: {type(environment).__name__}")
+        apiEnvironment=IMSSubscriptionsManagementAPIEnvironment(environment)
+        self._http_client = HttpClient(
+            azure_credential=azure_credential, resource_id=apiEnvironment.resource_id
+        )
+        self._base_url = apiEnvironment.base_url.rstrip("/")
+
+    def get_subscription_counter_by_system_code(
+        self,
+        systemCode: str,
+        **kwargs,
+    ) -> SubscriptionCounterModel:
+        """
+        Search IMS Subscriptions Management API
+        """
+        params = kwargs or {}
+        url = (
+            f"{self._base_url}/{systemCode}/counter"
+        )
+        return self._http_client.request(request_type="get", url=url, params=params)
+
+    def patch_subscription_by_uid(
+        self,
+        uid: str,
+        request: SubscriptionPatchRequestItem
+    ) -> GetIMSMetadataResponseModel:
+        """
+        Search IMS Subscriptions Management API
+        """
+        url = (
+            f"{self._base_url}/uid/{uid}"
+        )
+        return self._http_client.request(request_type="patch", url=url, payload=request)
+
+class TimeseriesAPI:
+    """
+    Wrapper class for interacting with the Omnia Industrial IIoT Timeseries API.
+    For more information, see https://github.com/equinor/OmniaPlant/wiki or consult with the Omnia IIoT team.
+
+    :param TokenCredential azure_credential: Azure token credential instance used for authenticating
+    :param TimeseriesEnvironment environment: API deployment environment
+    """
+
+    def __init__(
+        self, azure_credential: TokenCredential, environment: TimeseriesEnvironment
+    ):
+        if not isinstance(environment, TimeseriesEnvironment):
+            raise TypeError(f"Environment must be TimeseriesEnvironment, got: {type(environment).__name__}")
+        apiEnvironment=TimeseriesApiEnvironment(environment)
+        self._http_client = HttpClient(
+            azure_credential=azure_credential, resource_id=apiEnvironment.resource_id
+        )
+        self._base_url = apiEnvironment.base_url.rstrip("/")
         self._debug_mode = False
 
     def _add_debug_param(self, params: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/omnia_timeseries/http_client.py
+++ b/src/omnia_timeseries/http_client.py
@@ -1,5 +1,5 @@
-from typing import Literal, List, Optional, Union, Dict, Any
-from azure.identity._internal.msal_credentials import MsalCredential
+from typing import Literal, List, Optional, Union, Dict, Any, Mapping, Sequence
+from azure.core.credentials import TokenCredential
 import requests
 import logging
 
@@ -31,8 +31,8 @@ def _request(
     request_type: RequestType,
     url: str,
     headers: Dict[str, Any],
-    payload: Optional[Union[Dict, Dict, List]] = None,
-    params: Optional[Dict[str, Any]] = None,
+    payload: Optional[Mapping[str, Any] | Sequence[Any]] = None,
+    params: Optional[Mapping[str, Any]] = None,
 ) -> Union[Dict[str, Any], bytes]:
 
     response = requests.request(
@@ -47,7 +47,7 @@ def _request(
 
 
 class HttpClient:
-    def __init__(self, azure_credential: MsalCredential, resource_id: str):
+    def __init__(self, azure_credential: TokenCredential, resource_id: str):
         self._azure_credential = azure_credential
         self._resource_id = resource_id
 
@@ -56,8 +56,8 @@ class HttpClient:
         request_type: RequestType,
         url: str,
         accept: ContentType = "application/json",
-        payload: Optional[Union[Dict, Dict, List]] = None,
-        params: Optional[Dict[str, Any]] = None,
+        payload: Optional[Mapping[str, Any] | Sequence[Any]] = None,
+        params: Optional[Mapping[str, Any]] = None,
     ) -> Any:
 
         access_token = self._azure_credential.get_token(

--- a/src/omnia_timeseries/models.py
+++ b/src/omnia_timeseries/models.py
@@ -78,6 +78,44 @@ class GetAggregatesResponseModel(TypedDict):
     count: Optional[int]
     continuationToken: Optional[str]
 
+class IMSMetadataItemsModel(TypedDict):
+    items: List[IMSMetadataModel]
+
+class GetIMSMetadataResponseModel(TypedDict):
+    data: IMSMetadataItemsModel
+    count: Optional[int]
+    continuationToken: Optional[str]
+
+class IMSMetadataModel(TypedDict):
+    id: str
+    uid: str
+    imsType: str
+    systemCode: str
+    recordId: bool
+    plantSapCode: str
+    plantStidCode: str
+    tag: str
+    terminal: str
+    isDefaultTerminal: str
+    description: str
+    engUnits: str
+    standardUnit: str
+    source: str
+    type: str
+    sourceTag: str
+    stepped: str
+    changeDate: str
+    creationDate: str
+    currentValueDate: str
+    compressed: str
+    compressionDeviation: str
+    compressionMaximum: str
+    compressionMinimum: str
+    compressionDeviationPercent: str
+    plantArea: str
+    significantDigit: str
+    maxTimeInterval: str
+    fieldId: str
 
 class TimeseriesModel(TypedDict):
     id: str
@@ -103,6 +141,13 @@ class GetTimeseriesResponseModel(TypedDict):
     count: Optional[int]
     continuationToken: Optional[str]
 
+class SubscriptionPatchRequestItem(TypedDict, total=False):
+    name: Optional[str]
+    plantStidCode: Optional[str]
+    plantSapCode: Optional[bool]
+    terminal: Optional[str]
+    fieldId: Optional[str]
+    timeseriesId: Optional[str]
 
 class TimeseriesRequestItem(TypedDict, total=False):
     name: str
@@ -182,6 +227,9 @@ class StreamSubscriptionItemsModel(TypedDict):
 class StreamSubscriptionDataModel(TypedDict):
     data: StreamSubscriptionItemsModel
 
+class SubscriptionCounterModel(TypedDict):
+    quota: int
+    count: int
 
 class TimeseriesRequestFailedException(Exception):
     def __init__(self, response: Response) -> None:

--- a/src/omnia_timeseries/models.py
+++ b/src/omnia_timeseries/models.py
@@ -212,5 +212,5 @@ class TimeseriesRequestFailedException(Exception):
         return self._message
 
     @property
-    def trace_id(self) -> str:
+    def trace_id(self) -> Optional[str]:
         return self._trace_id

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,24 +1,19 @@
 import requests_mock
 import pytest
-from azure.identity._internal.msal_credentials import MsalCredential
 from azure.core.credentials import AccessToken
 from omnia_timeseries import TimeseriesAPI, TimeseriesEnvironment
 from omnia_timeseries.http_client import TimeseriesRequestFailedException
 
-
-class DummyCredentials(MsalCredential):
-
-    def get_token(self, *scopes, **kwargs):
+class DummyCredentials:
+    def get_token(self, *scopes: str, **kwargs) -> AccessToken:
         return AccessToken("dummytoken", 0)
-
-    def _get_app(self):
-        return None
 
 
 @pytest.fixture
 def api():
-    env = TimeseriesEnvironment("dummy", "https://test")
-    api = TimeseriesAPI(DummyCredentials("dummy"), env)
+    env = TimeseriesEnvironment.Dev()
+    api = TimeseriesAPI(azure_credential=DummyCredentials(), environment=env)
+    api._base_url = "https://test"
     return api
 
 


### PR DESCRIPTION
## Description
Add other api clients to interface with and reuse timeseries environment
- Enable pylance basic type validation checks and based on these validation errors change MsalCredential internal type to use generally available TokenCredential instead + properly set HttpClient expected request type
- Update TimeseriesEnvironment to instead be a generic way to set environment to dev, test or prod. User facing functionality is the same, except for the ability to set API version. As this is a supportive sdk and not our main API, I assume its not critical that user's cant go towards version 1.6 while the default has been and still is 1.7
- Add IMS Metadata API and related environment, and some endpoints
- Add IMS Subscriptions API and related environment, and some endpoints
- Add IMS Subscriptions Management API and related environment, and some endpoints. Meant for internal use. If users discovers it, no harm is done as they anyways would need admin token to be able to use it
- Should probably add more endpoints at some point, focus now was to have ready endpoints needed for SNB Remap operation, if its decided we will do that after all 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue): Pylance non-critical type validation errors
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected): No longer able to select Timeseries API version 1.6, only default/newest 1.7 is now supported

## How Has This Been Tested?
Tested locally with local build (`poetry build` and `pip install dist/omnia_timeseries-x.y.z.tar.gz`), and with the following code
```
# Import existing and new APIs
from omnia_timeseries.api import TimeseriesAPI, IMSMetadataAPI, IMSSubscriptionsAPI, IMSSubscriptionsManagementAPI, TimeseriesEnvironment, FederationSource
import os

# Setup credentials
from azure.identity import DefaultAzureCredential
credentials = DefaultAzureCredential()

# Set environment and API variables
environment=TimeseriesEnvironment.Dev()
api = TimeseriesAPI(azure_credential=credentials, environment=environment)
imsApi = IMSMetadataAPI(azure_credential=credentials, environment=environment)
subApi = IMSSubscriptionsAPI(azure_credential=credentials, environment=environment)
subManApi = IMSSubscriptionsManagementAPI(azure_credential=credentials, environment=environment)

# Ensure existing timeseries api call work, tested one endpoint
api.get_timeseries(limit=10)

# Ensure able to search for IMS Metadata API tags
imsApi.search(limit=10)

# Ensure able to search for IMS Subscriptions API subscriptions
print(subApi.search(limit=3))
print(subApi.search_by_system_code(systemCode="SNB"))
print(subApi.search_by_timeseries_id(timeseriesId="e70fda8b-5624-4089-a979-3c4ad8211a6c"))
print(subApi.search_by_uid(uid="SFB-2675"))

# Ensure able to use IMS Subscriptions API
subManApi.get_subscription_counter_by_system_code(systemCode="SNB")
subManApi.patch_subscription_by_uid(
    uid="SFB-2675",
    request= 
        {
            "propertyX":"valueX"
        }
    )
```

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes