### PR TITLE
Fix backwards compatibility for Python v3.8 and v3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "omnia_timeseries"
-version = "1.4.4"
+version = "1.4.4.1"
 description = "Official Python SDK for the Omnia Timeseries API"
 readme = "README.md"
 authors = ["Equinor Omnia Industrial IoT Team <omniaindiot@equinor.com>"]
@@ -40,5 +40,5 @@ extend-exclude = '''
 '''
 
 [build-system]
-requires = ["poetry-core>=2.0,<3.0"]
+requires = [ "poetry-core>=1.8,<2.0; python_version < '3.9'", "poetry-core>=2.0,<3.0; python_version >= '3.9'" ]
 build-backend = "poetry.core.masonry.api"

--- a/src/omnia_timeseries/http_client.py
+++ b/src/omnia_timeseries/http_client.py
@@ -31,7 +31,7 @@ def _request(
     request_type: RequestType,
     url: str,
     headers: Dict[str, Any],
-    payload: Optional[Mapping[str, Any] | Sequence[Any]] = None,
+    payload: Optional[Union[Mapping[str, Any], Sequence[Any]]] = None,
     params: Optional[Mapping[str, Any]] = None,
 ) -> Union[Dict[str, Any], bytes]:
 
@@ -56,7 +56,7 @@ class HttpClient:
         request_type: RequestType,
         url: str,
         accept: ContentType = "application/json",
-        payload: Optional[Mapping[str, Any] | Sequence[Any]] = None,
+        payload: Optional[Union[Mapping[str, Any], Sequence[Any]]] = None,
         params: Optional[Mapping[str, Any]] = None,
     ) -> Any:
 

--- a/src/omnia_timeseries/models.py
+++ b/src/omnia_timeseries/models.py
@@ -78,13 +78,6 @@ class GetAggregatesResponseModel(TypedDict):
     count: Optional[int]
     continuationToken: Optional[str]
 
-class IMSMetadataItemsModel(TypedDict):
-    items: List[IMSMetadataModel]
-
-class GetIMSMetadataResponseModel(TypedDict):
-    data: IMSMetadataItemsModel
-    count: Optional[int]
-    continuationToken: Optional[str]
 
 class IMSMetadataModel(TypedDict):
     id: str
@@ -116,6 +109,14 @@ class IMSMetadataModel(TypedDict):
     significantDigit: str
     maxTimeInterval: str
     fieldId: str
+
+class IMSMetadataItemsModel(TypedDict):
+    items: List[IMSMetadataModel]
+
+class GetIMSMetadataResponseModel(TypedDict):
+    data: IMSMetadataItemsModel
+    count: Optional[int]
+    continuationToken: Optional[str]
 
 class TimeseriesModel(TypedDict):
     id: str


### PR DESCRIPTION
## Description
Fix for [Bug 31863](https://dev.azure.com/Plant-Data-Platform-Team/Omnia%20Industrial%20IoT%20Team/_workitems/edit/31863): Error with IMSMetadataModel during import in Python v3.9.13
- Ensure IMSMetadataModel is defined first before attempts to use it below. Newer Python versions doesn't care about the order but v3.9 (and probably v3.8 also) cared
- Ensure Union is used instead of pipe "|" symbol which is only supported in Python versions v3.10 and higher
- Ensure poetry toml file allows v3.8 to build by allowing poetry core 1x versions which v3.8 support, as v3.8 does not support 2x versions and above
- And optionally, see more debug info in task

User was on v3.9.21, but luckily was able to reproduce on v3.9.13 (latest .exe windows file available)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected): Probably few v3.8 Python users out there as no v3.8 user has complained yet, building newest version was failing, so either they are not using it or they are on old version of our sdk which actually supported v3.8. So this change will fix breaking change from previous releases

## How Has This Been Tested?
Tested locally with `poetry build` (incrementing version in poetry toml file for local debugging to know which version im testing)
- [x] Installed necessary Python versions which we are supposed to support
  - [x] Python v3.8: Admin powershell with `winget install -e --id Python.Python.3.8`
  - [x] Python v3.9: Install https://www.python.org/ftp/python/3.9.13/ as admin from `C:\Appl`
  - [x] Python v3.10: Install https://www.python.org/ftp/python/3.10.9/ as admin from `C:\Appl`
  - [x] Python v3.11: Install https://www.python.org/ftp/python/3.11.9/ as admin from `C:\Appl`
  - [x] Python v3.12: Install https://www.python.org/ftp/python/3.12.9/ as admin from `C:\Appl`
  - [x] Python v3.13: Install https://www.python.org/ftp/python/3.13.9/ as admin from `C:\Appl`
  - [x] Python v3.14: Already had it locally
- [x] Open project in `Visual Studio Code`, go to `usage_examples.ipynb` and in top right corner select python (kernel) version, and `Clear All Outputs` and `Restart` kernel
- [x] Try to run the following
  ```
  import os, sys, platform
  print("Python version:", platform.python_version())
  print("Detailed:", sys.version)
  print("Interpreter path:", sys.executable)
  from omnia_timeseries.api import TimeseriesAPI, TimeseriesEnvironment
  from azure.identity import DefaultAzureCredential
  credentials = DefaultAzureCredential()
  environment=TimeseriesEnvironment.Dev()
  api = TimeseriesAPI(azure_credential=credentials, environment=environment)
  api.get_timeseries(limit=1)
  ``` 
- [x] Fix issues locally, rebuild with `poetry build` and install necessary packages into Python version with `py -3.9 -m pip install azure.identity, ipykernel, requests_mock, pytest, dist/omnia_timeseries-1.4.4.1.tar.gz`. Try code block above again and see that it builds fine and is able get data back with sdk + open terminal in vscode, if any existing terminal delete/kill them, in lower left cog wheel select `Python: Select Interpretor` and select python version, then right click `test_api.py` and select `Run Tests` and verify tests are green/work and that the tests were run on the expected version
- [x] Fix issues locally, rebuild with `poetry build` and install necessary packages into Python version with `py -3.8 -m pip install azure.identity, ipykernel, requests_mock, pytest, dist/omnia_timeseries-1.4.4.1.tar.gz`. Try code block above again and see that it builds fine and is able get data back with sdk + open terminal in vscode, if any existing terminal delete/kill them, in lower left cog wheel select `Python: Select Interpretor` and select python version, then right click `test_api.py` and select `Run Tests` and verify tests are green/work and that the tests were run on the expected version
- [x] Do the same verifications for the other versions as well, all the way up until and including v3.14

Was breaking for v3.9 and v3.8, example of verification below. Tested each of the other versions inbetween also, no compatibility issues there

**v3.9**
<img width="1424" height="796" alt="image" src="https://github.com/user-attachments/assets/b54e1e90-ebf2-4d0a-bfb2-eb201d03ba7b" />

<img width="1432" height="377" alt="image" src="https://github.com/user-attachments/assets/c7e20371-a982-48a4-ae74-3e436698b0cb" />

**v3.8**
<img width="1430" height="806" alt="image" src="https://github.com/user-attachments/assets/c138560b-12e2-47a8-ab42-46f58ee96020" />

<img width="1434" height="365" alt="image" src="https://github.com/user-attachments/assets/77374f5b-7f1c-46f9-9393-6228dc47d5a1" />

## Checklist:
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
