### PR TITLE
32211 Add state parent class to subscription patch request

### DIFF
--- a/src/omnia_timeseries/models.py
+++ b/src/omnia_timeseries/models.py
@@ -110,13 +110,16 @@ class IMSMetadataModel(TypedDict):
     maxTimeInterval: str
     fieldId: str
 
+
 class IMSMetadataItemsModel(TypedDict):
     items: List[IMSMetadataModel]
+
 
 class GetIMSMetadataResponseModel(TypedDict):
     data: IMSMetadataItemsModel
     count: Optional[int]
     continuationToken: Optional[str]
+
 
 class TimeseriesModel(TypedDict):
     id: str
@@ -142,13 +145,30 @@ class GetTimeseriesResponseModel(TypedDict):
     count: Optional[int]
     continuationToken: Optional[str]
 
-class SubscriptionPatchRequestItem(TypedDict, total=False):
+
+class SubscriptionStatePatchModel(TypedDict, total=False):
+    tsdbBackfilled: Optional[bool]
+    tsdbEventsExported: Optional[int]
+    tsdbFirstExportedTime: Optional[str]
+    tsdbLastExportedTime: Optional[str]
+    dlBackfilled: Optional[bool]
+    dlEventsExported: Optional[int]
+    dlFirstExportedTime: Optional[str]
+    dlLastExportedTime: Optional[str]
+    dlParquetFirstExportedTime: Optional[str]
+    dlParquetLastExportedTime: Optional[str]
+    sourceFirstCountedTime: Optional[str]
+    sourceLastCountedTime: Optional[str]
+
+
+class SubscriptionPatchRequestItem(SubscriptionStatePatchModel, total=False):
     name: Optional[str]
     plantStidCode: Optional[str]
-    plantSapCode: Optional[bool]
+    plantSapCode: Optional[str]
     terminal: Optional[str]
     fieldId: Optional[str]
     timeseriesId: Optional[str]
+
 
 class TimeseriesRequestItem(TypedDict, total=False):
     name: str
@@ -228,9 +248,11 @@ class StreamSubscriptionItemsModel(TypedDict):
 class StreamSubscriptionDataModel(TypedDict):
     data: StreamSubscriptionItemsModel
 
+
 class SubscriptionCounterModel(TypedDict):
     quota: int
     count: int
+
 
 class TimeseriesRequestFailedException(Exception):
     def __init__(self, response: Response) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 
 import requests_mock
 import pytest

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -166,7 +166,7 @@ def should_patch_subscription_by_uid_with_state_fields_only(ims_sub_mgmt_api):
         assert response["count"] == 0
 
 
-def should_patch_subscription_by_uid_with_complete_model(ims_sub_mgmt_api):
+def should_patch_subscription_by_uid_with_subscription_and_state_fields(ims_sub_mgmt_api):
     payload = {
         "plantStidCode": "asdf-1234",
         "plantSapCode": "1234",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,7 +22,7 @@ def api():
 
 
 @pytest.fixture
-def ims_sub_mgmt_api():
+def imssubscriptionsmanagementapi():
     env = TimeseriesEnvironment.Dev()
     api = IMSSubscriptionsManagementAPI(
         azure_credential=DummyCredentials(),
@@ -135,7 +135,9 @@ def should_include_debug_query_param_when_debug_mode_is_enabled(api):
         )
 
 
-def should_patch_subscription_by_uid_with_state_fields_only(ims_sub_mgmt_api):
+def should_patch_subscription_by_uid_with_state_fields_only(
+    imssubscriptionsmanagementapi,
+):
     payload = {
         "tsdbEventsExported": 0,
         "tsdbFirstExportedTime": None,
@@ -154,7 +156,7 @@ def should_patch_subscription_by_uid_with_state_fields_only(ims_sub_mgmt_api):
             json={"data": {"items": []}, "count": 0},
         )
 
-        response = ims_sub_mgmt_api.patch_subscription_by_uid(
+        response = imssubscriptionsmanagementapi.patch_subscription_by_uid(
             uid="sub-123",
             request=payload,
         )
@@ -166,7 +168,9 @@ def should_patch_subscription_by_uid_with_state_fields_only(ims_sub_mgmt_api):
         assert response["count"] == 0
 
 
-def should_patch_subscription_by_uid_with_subscription_and_state_fields(ims_sub_mgmt_api):
+def should_patch_subscription_by_uid_with_subscription_and_state_fields(
+    imssubscriptionsmanagementapi,
+):
     payload = {
         "plantStidCode": "asdf-1234",
         "plantSapCode": "1234",
@@ -187,7 +191,7 @@ def should_patch_subscription_by_uid_with_subscription_and_state_fields(ims_sub_
             json={"data": {"items": []}, "count": 0},
         )
 
-        response = ims_sub_mgmt_api.patch_subscription_by_uid(
+        response = imssubscriptionsmanagementapi.patch_subscription_by_uid(
             uid="sub-123",
             request=payload,
         )
@@ -200,7 +204,7 @@ def should_patch_subscription_by_uid_with_subscription_and_state_fields(ims_sub_
 
 
 def should_raise_on_patch_subscription_by_uid_when_api_returns_400(
-    ims_sub_mgmt_api,
+    imssubscriptionsmanagementapi,
 ):
     payload = {
         "tsdbEventsExported": 1,
@@ -216,7 +220,7 @@ def should_raise_on_patch_subscription_by_uid_when_api_returns_400(
         )
 
         with pytest.raises(TimeseriesRequestFailedException) as exc:
-            ims_sub_mgmt_api.patch_subscription_by_uid(
+            imssubscriptionsmanagementapi.patch_subscription_by_uid(
                 uid="sub-123",
                 request=payload,
             )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,3 +198,30 @@ def should_patch_subscription_by_uid_with_complete_model(ims_sub_mgmt_api):
         assert request.method == "PATCH"
         assert json.loads(request.text) == payload
         assert response["count"] == 0
+
+
+def should_fail_patch_subscription_by_uid_when_payload_has_disallowed_field(
+    ims_sub_mgmt_api,
+):
+    payload = {
+        "tsdbEventsExported": 1,
+        "notAllowedField": "boom",  # not part of SubscriptionPatchRequestItem
+    }
+
+    with requests_mock.Mocker() as m:
+        m.register_uri(
+            "PATCH",
+            "https://test/uid/sub-123",
+            status_code=400,
+            text='{"message":"Invalid field: notAllowedField","traceId":"trace-1"}',
+        )
+
+        with pytest.raises(TimeseriesRequestFailedException) as exc:
+            ims_sub_mgmt_api.patch_subscription_by_uid(
+                uid="sub-123",
+                request=payload,
+            )
+
+        assert m.call_count == 1
+        assert exc.value.status_code == 400
+        assert "Invalid field" in exc.value.message

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,8 +1,13 @@
+import json
+from typing import Optional
+
 import requests_mock
 import pytest
 from azure.core.credentials import AccessToken
 from omnia_timeseries import TimeseriesAPI, TimeseriesEnvironment
+from omnia_timeseries.api import IMSSubscriptionsManagementAPI
 from omnia_timeseries.http_client import TimeseriesRequestFailedException
+
 
 class DummyCredentials:
     def get_token(self, *scopes: str, **kwargs) -> AccessToken:
@@ -13,6 +18,17 @@ class DummyCredentials:
 def api():
     env = TimeseriesEnvironment.Dev()
     api = TimeseriesAPI(azure_credential=DummyCredentials(), environment=env)
+    api._base_url = "https://test"
+    return api
+
+
+@pytest.fixture
+def ims_sub_mgmt_api():
+    env = TimeseriesEnvironment.Dev()
+    api = IMSSubscriptionsManagementAPI(
+        azure_credential=DummyCredentials(),
+        environment=env,
+    )
     api._base_url = "https://test"
     return api
 
@@ -84,9 +100,9 @@ def should_forward_align_to_cache_parameter_for_multi_datapoints(api):
         api.get_multi_datapoints([{"id": "series-1"}], alignToCache=True)
         assert m.call_count == 1, "Expected a single request"
         request = m.request_history[0]
-        assert request.qs.get("aligntocache") == [
-            "true"
-        ], "alignToCache should be forwarded"
+        assert request.qs.get("aligntocache") == ["true"], (
+            "alignToCache should be forwarded"
+        )
 
 
 def should_forward_align_to_cache_parameter_for_get_aggregates(api):
@@ -99,9 +115,9 @@ def should_forward_align_to_cache_parameter_for_get_aggregates(api):
         api.get_aggregates("1234", ["avg"], alignToCache=False)
         assert m.call_count == 1, "Expected a single request"
         request = m.request_history[0]
-        assert request.qs.get("aligntocache") == [
-            "false"
-        ], "alignToCache should be forwarded as false"
+        assert request.qs.get("aligntocache") == ["false"], (
+            "alignToCache should be forwarded as false"
+        )
 
 
 def should_include_debug_query_param_when_debug_mode_is_enabled(api):
@@ -115,6 +131,70 @@ def should_include_debug_query_param_when_debug_mode_is_enabled(api):
         api.get_multi_datapoints([{"id": "series-1"}])
         assert m.call_count == 1, "Expected a single request"
         request = m.request_history[0]
-        assert request.qs.get("debug") == [
-            "true"
-        ], "Debug mode should inject debug=true"
+        assert request.qs.get("debug") == ["true"], (
+            "Debug mode should inject debug=true"
+        )
+
+
+def should_patch_subscription_by_uid_with_state_fields_only(ims_sub_mgmt_api):
+    payload = {
+        "tsdbEventsExported": 0,
+        "tsdbFirstExportedTime": None,
+        "tsdbLastExportedTime": None,
+        "dlEventsExported": 0,
+        "dlFirstExportedTime": None,
+        "dlLastExportedTime": None,
+        "sourceFirstCountedTime": None,
+        "sourceLastCountedTime": None,
+    }
+
+    with requests_mock.Mocker() as m:
+        m.register_uri(
+            "PATCH",
+            "https://test/uid/sub-123",
+            json={"data": {"items": []}, "count": 0},
+        )
+
+        response = ims_sub_mgmt_api.patch_subscription_by_uid(
+            uid="sub-123",
+            request=payload,
+        )
+
+        assert m.call_count == 1
+        request = m.request_history[0]
+        assert request.method == "PATCH"
+        assert json.loads(request.text) == payload
+        assert response["count"] == 0
+
+
+def should_patch_subscription_by_uid_with_complete_model(ims_sub_mgmt_api):
+    payload = {
+        "plantStidCode": "asdf-1234",
+        "plantSapCode": "1234",
+        "tsdbEventsExported": 0,
+        "tsdbFirstExportedTime": None,
+        "tsdbLastExportedTime": None,
+        "dlEventsExported": 0,
+        "dlFirstExportedTime": None,
+        "dlLastExportedTime": None,
+        "sourceFirstCountedTime": None,
+        "sourceLastCountedTime": None,
+    }
+
+    with requests_mock.Mocker() as m:
+        m.register_uri(
+            "PATCH",
+            "https://test/uid/sub-123",
+            json={"data": {"items": []}, "count": 0},
+        )
+
+        response = ims_sub_mgmt_api.patch_subscription_by_uid(
+            uid="sub-123",
+            request=payload,
+        )
+
+        assert m.call_count == 1
+        request = m.request_history[0]
+        assert request.method == "PATCH"
+        assert json.loads(request.text) == payload
+        assert response["count"] == 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -199,12 +199,12 @@ def should_patch_subscription_by_uid_with_subscription_and_state_fields(ims_sub_
         assert response["count"] == 0
 
 
-def should_fail_patch_subscription_by_uid_when_payload_has_disallowed_field(
+def should_raise_on_patch_subscription_by_uid_when_api_returns_400(
     ims_sub_mgmt_api,
 ):
     payload = {
         "tsdbEventsExported": 1,
-        "notAllowedField": "boom",  # not part of SubscriptionPatchRequestItem
+        "notAllowedField": "boom",  # field intentionally unknown; API returns 400
     }
 
     with requests_mock.Mocker() as m:


### PR DESCRIPTION
Added parent class with state parameters that the ims subscription management api allows for the patch endpoint. Intentionally left the datalastaccessed parameter out as this is intended to be used/maintained via function app.
Added some simple tests for the endpoint.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I Have run existing and new tests

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding changes to the architecture
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
