### PR TITLE
feat: add trusted PyPI publishing workflow and package metadata

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -23,9 +23,8 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Verify tag matches pyproject version
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
           PYPROJECT_VERSION=$(python - <<'PY'
           import tomllib
 
@@ -35,8 +34,10 @@ jobs:
           PY
           )
 
-          if [[ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]]; then
-            echo "Tag version ($TAG_VERSION) does not match pyproject version ($PYPROJECT_VERSION)."
+          EXPECTED_TAG="v${PYPROJECT_VERSION}"
+
+          if [[ "$GITHUB_REF_NAME" != "$EXPECTED_TAG" ]]; then
+            echo "Release tag must be '${EXPECTED_TAG}', but got '${GITHUB_REF_NAME}'."
             exit 1
           fi
 

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,83 @@
+name: Publish Python Package
+
+'on':
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      publish_to_testpypi:
+        description: Publish package to TestPyPI instead of PyPI
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Check package metadata
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+  publish-testpypi:
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_to_testpypi
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+    environment:
+      name: development
+      url: https://test.pypi.org/p/omnia-timeseries
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to TestPyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      id-token: write
+    environment:
+      name: production
+      url: https://pypi.org/p/omnia-timeseries
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,6 +2,8 @@ name: Publish Python Package
 
 'on':
   push:
+    branches:
+      - feature/make-ready-for-publish-on-pypi
     tags:
       - v*
   workflow_dispatch:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -2,8 +2,6 @@ name: Publish Python Package
 
 'on':
   push:
-    branches:
-      - feature/make-ready-for-publish-on-pypi
     tags:
       - v*
   workflow_dispatch:
@@ -45,9 +43,7 @@ jobs:
           path: dist/
 
   publish-testpypi:
-    if: |
-        (github.event_name == 'workflow_dispatch' && inputs.publish_to_testpypi) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/feature/make-ready-for-publish-on-pypi')
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_to_testpypi
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -45,7 +45,9 @@ jobs:
           path: dist/
 
   publish-testpypi:
-    if: github.event_name == 'workflow_dispatch' && inputs.publish_to_testpypi
+    if: |
+        (github.event_name == 'workflow_dispatch' && inputs.publish_to_testpypi) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/feature/make-ready-for-publish-on-pypi')
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -43,7 +43,7 @@ jobs:
           path: dist/
 
   publish-testpypi:
-    if: github.event_name == 'workflow_dispatch' && inputs.publish_to_testpypi
+    if: github.event_name == 'workflow_dispatch' && fromJSON(inputs.publish_to_testpypi)
     runs-on: ubuntu-latest
     needs: build
     permissions:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,6 +22,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Verify tag matches pyproject version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PYPROJECT_VERSION=$(python - <<'PY'
+          import tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+          print(data["tool"]["poetry"]["version"])
+          PY
+          )
+
+          if [[ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]]; then
+            echo "Tag version ($TAG_VERSION) does not match pyproject version ($PYPROJECT_VERSION)."
+            exit 1
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,26 @@ Here are some resources to help you get started with open source contributions:
 * Create a PR
 * Code review
 
+### Release and versioning
+
+Follow the steps below for any release that is intended for PyPI.
+
+1. Update the package version in `pyproject.toml` under `[tool.poetry].version`.
+2. Update `CHANGELOG.md` with the release notes for that exact version.
+3. Merge the release PR to `main`.
+4. Create and push a Git tag that exactly matches the package version prefixed with `v`.
+
+Examples:
+
+- `pyproject.toml` version `1.4.5` -> tag `v1.4.5`
+- `pyproject.toml` version `1.4.5.post1` -> tag `v1.4.5.post1`
+
+Versioning policy:
+
+- Use `X.Y.Z` for normal releases (features/fixes).
+- Use `X.Y.Z.postN` for packaging-only corrections where runtime behavior is unchanged.
+- Do not create a release tag without first updating `pyproject.toml` to the matching version.
+
 ### Issues
 
 #### Create a new issue

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install from GitHub (latest unreleased changes):
 pip install git+https://github.com/equinor/omnia-timeseries-python.git@main
 ```
 
-Supported Python versions: 3.8+
+Supported Python versions: 3.8+ (excluding 3.9.0 and 3.9.1)
 
 For support, create an issue on GitHub.
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,21 @@
 
 Python package for interacting with the [Omnia Industrial IoT Timeseries API](https://github.com/equinor/OmniaPlant/wiki).
 
-## How do I get set up? ###
+## Installation
 
-To use the Python package, install it in the following manner:
+Install from PyPI:
+
+```
+pip install omnia-timeseries
+```
+
+Install from GitHub (latest unreleased changes):
 
 ```
 pip install git+https://github.com/equinor/omnia-timeseries-python.git@main
 ```
+
+Supported Python versions: 3.8+
 
 For support, create an issue on GitHub.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "omnia_timeseries"
-version = "1.4.4.1"
+version = "1.4.4.3"
 description = "Official Python SDK for the Omnia Timeseries API"
 readme = "README.md"
 authors = ["Equinor Omnia Industrial IoT Team <omniaindiot@equinor.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,17 +10,17 @@ repository = "https://github.com/equinor/omnia-timeseries-python"
 documentation = "https://github.com/equinor/omnia-timeseries-python/blob/main/README.md"
 keywords = ["omnia", "timeseries", "azure", "sdk", "industrial-iot"]
 classifiers = [
-	"Development Status :: 5 - Production/Stable",
-	"Intended Audience :: Developers",
-	"License :: OSI Approved :: MIT License",
-	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.8",
-	"Programming Language :: Python :: 3.9",
-	"Programming Language :: Python :: 3.10",
-	"Programming Language :: Python :: 3.11",
-	"Programming Language :: Python :: 3.12",
-	"Programming Language :: Python :: 3.13",
-	"Topic :: Software Development :: Libraries :: Python Modules",
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 packages = [{ include = "omnia_timeseries", from = "src" }]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,25 @@ version = "1.4.4.1"
 description = "Official Python SDK for the Omnia Timeseries API"
 readme = "README.md"
 authors = ["Equinor Omnia Industrial IoT Team <omniaindiot@equinor.com>"]
-license = "LICENSE"
+license = "MIT"
+homepage = "https://github.com/equinor/omnia-timeseries-python"
+repository = "https://github.com/equinor/omnia-timeseries-python"
+documentation = "https://github.com/equinor/omnia-timeseries-python/blob/main/README.md"
+keywords = ["omnia", "timeseries", "azure", "sdk", "industrial-iot"]
+classifiers = [
+	"Development Status :: 5 - Production/Stable",
+	"Intended Audience :: Developers",
+	"License :: OSI Approved :: MIT License",
+	"Programming Language :: Python :: 3",
+	"Programming Language :: Python :: 3.8",
+	"Programming Language :: Python :: 3.9",
+	"Programming Language :: Python :: 3.10",
+	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
+	"Programming Language :: Python :: 3.13",
+	"Topic :: Software Development :: Libraries :: Python Modules",
+]
+packages = [{ include = "omnia_timeseries", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.9.0 || >3.9.1,<4.0"
@@ -26,6 +44,8 @@ black = ">=22.0,<26.0"
 
 [tool.poetry.urls]
 repository = "https://github.com/equinor/omnia-timeseries-python"
+issues = "https://github.com/equinor/omnia-timeseries-python/issues"
+changelog = "https://github.com/equinor/omnia-timeseries-python/blob/main/CHANGELOG.md"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
add GitHub Actions workflow for trusted publishing to TestPyPI (manual) and PyPI (tag-based) enrich package metadata (license SPDX, URLs, keywords, classifiers, package include) mark package maturity as Production/Stable
update README with PyPI install instructions and supported Python version

## Description

This pull request enhances the packaging, publishing, and documentation setup for the Omnia Timeseries Python SDK. The most significant changes include the addition of a GitHub Actions workflow for automated publishing to PyPI and TestPyPI, improvements to the `pyproject.toml` metadata, and updated installation instructions in the `README.md`.

**Packaging and Publishing Automation:**
- Added a new GitHub Actions workflow (`.github/workflows/publish-pypi.yml`) to automate building and publishing the package to PyPI and TestPyPI, supporting both tag-based and manual dispatch releases.

**Project Metadata Improvements:**
- Updated `pyproject.toml` to include license change to MIT, added homepage, repository, documentation links, keywords, classifiers, and explicit package inclusion for `omnia_timeseries`.
- Added `issues` and `changelog` URLs under `[tool.poetry.urls]` in `pyproject.toml`.

**Documentation Updates:**
- Improved installation instructions in `README.md` to clearly show how to install from PyPI or GitHub, and specified supported Python versions.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test publishing on testpypi (test.pypi.org)

**Test Configuration**:
* Environment: development

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding changes to the architecture
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
