### PR TITLE
Require Python310 or above

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ Here are some resources to help you get started with open source contributions:
 * Create a PR
 * Code review
 
+### Run tests
+
+Run tests from the project root.
+
+1. Install dependencies:
+    - `poetry install`
+2. Run all tests:
+    - `poetry run pytest`
+3. Run a single test file (optional):
+    - `poetry run pytest tests/test_api.py`
+4. Run a single test case by name (optional):
+    - `poetry run pytest -k "test_name"`
+
+Before opening a PR, ensure tests pass locally.
+
 ### Release and versioning
 
 Follow the steps below for any release that is intended for PyPI.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install from GitHub (latest unreleased changes):
 pip install git+https://github.com/equinor/omnia-timeseries-python.git@main
 ```
 
-Supported Python versions: >=3.10
+Supported Python versions: 3.10+
 
 For support, create an issue on GitHub.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Install from GitHub (latest unreleased changes):
 pip install git+https://github.com/equinor/omnia-timeseries-python.git@main
 ```
 
+Install from a specific Git tag (for example, if you need an earlier SDK version):
+
+```
+pip install git+https://github.com/equinor/omnia-timeseries-python.git@vX.Y.Z
+```
+
 Supported Python versions: 3.10+
 
 For support, create an issue on GitHub.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install from GitHub (latest unreleased changes):
 pip install git+https://github.com/equinor/omnia-timeseries-python.git@main
 ```
 
-Supported Python versions: 3.8+ (excluding 3.9.0 and 3.9.1)
+Supported Python versions: >=3.10
 
 For support, create an issue on GitHub.
 

--- a/examples/get_data_protobuf.ipynb
+++ b/examples/get_data_protobuf.ipynb
@@ -120,7 +120,7 @@
    "hash": "c4733b2b9ae9b4529117b1eacf27fa8f502034d92f5f116530d195fc65f7cce0"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 64-bit ('.venv': venv)",
+   "display_name": "Python 3.10+ 64-bit ('.venv': venv)",
    "name": "python3"
   },
   "language_info": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "omnia_timeseries"
-version = "1.4.4.3"
+version = "2.0.0"
 description = "Official Python SDK for the Omnia Timeseries API"
 readme = "README.md"
 authors = ["Equinor Omnia Industrial IoT Team <omniaindiot@equinor.com>"]
@@ -14,8 +14,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -25,7 +23,7 @@ classifiers = [
 packages = [{ include = "omnia_timeseries", from = "src" }]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.9.0 || >3.9.1,<4.0"
+python = ">=3.10,<4.0"
 requests = ">=2.28.0,<3.0.0"
 azure-identity = ">=1.19.0,<2.0.0"
 azure-core = ">=1.30.0,<2.0.0"
@@ -49,7 +47,7 @@ changelog = "https://github.com/equinor/omnia-timeseries-python/blob/main/CHANGE
 
 [tool.black]
 line-length = 88
-target-version = ['py39']
+target-version = ['py310']
 include = '\.pyi?$'
 exclude = '^/src/version.py'
 extend-exclude = '''
@@ -60,5 +58,5 @@ extend-exclude = '''
 '''
 
 [build-system]
-requires = [ "poetry-core>=1.8,<2.0; python_version < '3.9'", "poetry-core>=2.0,<3.0; python_version >= '3.9'" ]
+requires = [ "poetry-core>=2.0,<3.0" ]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ azure-identity = ">=1.19.0,<2.0.0"
 azure-core = ">=1.30.0,<2.0.0"
 opentelemetry-instrumentation-requests = ">=0.54b1,<1.0.0"
 opentelemetry-api = ">=1.27.0,<2.0.0"
-cryptography = ">=46.0.5,<47.0.0"
+cryptography = ">=48.0.1,<49.0.0"
 pyjwt = ">=2.9.0,<3.0.0"
 
 [tool.poetry.group.test.dependencies]

--- a/src/omnia_timeseries/http_client.py
+++ b/src/omnia_timeseries/http_client.py
@@ -1,4 +1,4 @@
-from typing import Literal, List, Optional, Union, Dict, Any, Mapping, Sequence
+from typing import Literal, Optional, Dict, Any, Mapping, Sequence
 from azure.core.credentials import TokenCredential
 import requests
 import logging
@@ -31,9 +31,9 @@ def _request(
     request_type: RequestType,
     url: str,
     headers: Dict[str, Any],
-    payload: Optional[Union[Mapping[str, Any], Sequence[Any]]] = None,
+    payload: Optional[Mapping[str, Any] | Sequence[Any]] = None,
     params: Optional[Mapping[str, Any]] = None,
-) -> Union[Dict[str, Any], bytes]:
+) -> Dict[str, Any] | bytes:
 
     response = requests.request(
         request_type, url, headers=headers, json=payload, params=params
@@ -56,7 +56,7 @@ class HttpClient:
         request_type: RequestType,
         url: str,
         accept: ContentType = "application/json",
-        payload: Optional[Union[Mapping[str, Any], Sequence[Any]]] = None,
+        payload: Optional[Mapping[str, Any] | Sequence[Any]] = None,
         params: Optional[Mapping[str, Any]] = None,
     ) -> Any:
 


### PR DESCRIPTION
## Description

This pull request introduces breaking changes to the Omnia Timeseries Python SDK, including a major version bump to 2.0.0. The main focus is on dropping support for older Python versions (now requiring Python 3.10+), updating dependencies, and improving documentation for contributors. The most important changes are as follows:

**Python Version and Dependency Updates:**

* Dropped support for Python 3.8 and 3.9, now requiring Python >=3.10 and updating all documentation and classifiers accordingly (`pyproject.toml`, `README.md`). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L28-R32) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L17-L18) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19)
* Updated `cryptography` dependency to require version >=48.0.1,<49.0.0.
* Updated Black configuration and build system settings to align with Python 3.10+ (e.g., `target-version`, `poetry-core` requirements). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L52-R50) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L63-R61)

**Versioning:**

* Bumped package version to 2.0.0 to reflect breaking changes.

**Documentation Improvements:**

* Added a new section to `CONTRIBUTING.md` with clear instructions on how to run tests locally using Poetry and pytest before submitting a pull request.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] All unit-tests passed
- [x] Local testing

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding changes to the architecture
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
